### PR TITLE
fix(parser): update parser plugins

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -42,7 +42,6 @@ function _parse(src, filePath, sourceType) {
       'jsx',
       'typescript',
       'asyncDoExpressions',
-      'decimal',
       'decorators',
       'decoratorAutoAccessors',
       'deferredImportEvaluation',
@@ -53,7 +52,6 @@ function _parse(src, filePath, sourceType) {
       'functionBind',
       'functionSent',
       'importAttributes',
-      'importReflection',
       'moduleBlocks',
       ['optionalChainingAssign', {
         version: '2023-07'

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -52,6 +52,7 @@ function _parse(src, filePath, sourceType) {
       'functionBind',
       'functionSent',
       'importAttributes',
+      'sourcePhaseImports',
       'moduleBlocks',
       ['optionalChainingAssign', {
         version: '2023-07'


### PR DESCRIPTION
Fix babel parser plugin setting, causing errors:
* `The 'decimal' plugin has been removed in Babel 8. Please remove it from your configuration.`
* `The 'importReflection' plugin has been removed in Babel 8. Use 'sourcePhaseImports' instead, and replace 'import module' with 'import source' in your code.`